### PR TITLE
feat(mojaloop/#3409): add initial grafana cb svc dashboard

### DIFF
--- a/docker/grafana/provisioning/dashboards/Supporting Services - Callback Hander Service-1689261777383.json
+++ b/docker/grafana/provisioning/dashboards/Supporting Services - Callback Hander Service-1689261777383.json
@@ -1,26 +1,4 @@
 {
-  "__inputs": [],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "10.0.2"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph (old)",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -40,28 +18,50 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
     {
-      "description": "Party Callbacks / Sec",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "0"
-                }
-              },
-              "type": "special"
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
-          ],
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -74,65 +74,87 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "ops"
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
+        "h": 8,
+        "w": 12,
         "x": 0,
         "y": 0
       },
-      "id": 123128,
-      "links": [],
-      "maxDataPoints": 100,
+      "id": 123132,
       "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^Party Callbacks / Sec$/",
-          "values": false
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
-        "textMode": "auto"
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
-      "pluginVersion": "10.0.2",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "editorMode": "code",
-          "expr": "sum(irate(tx_cb_perf_bucket{operation=\"get_parties_end2end\"}[30s]))",
-          "instant": true,
-          "legendFormat": "Party Callbacks / Sec",
+          "expr": "irate(cbs_ing_callbackHandler_sum[30s]) / irate(cbs_ing_callbackHandler_count[30s])",
+          "instant": false,
+          "legendFormat": "op: {{operation}} success: {{success}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Party Callbacks / Sec",
-      "type": "stat"
+      "title": "Handler Ingress  - Processing Time",
+      "type": "timeseries"
     },
     {
-      "description": "Participant Callbacks / Sec",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "0"
-                }
-              },
-              "type": "special"
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
-          ],
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -145,52 +167,55 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "ops"
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
+        "h": 8,
+        "w": 12,
+        "x": 12,
         "y": 0
       },
-      "id": 123129,
-      "links": [],
-      "maxDataPoints": 100,
+      "id": 123131,
       "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^Participant Callbacks / Sec$/",
-          "values": false
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
-        "textMode": "auto"
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
-      "pluginVersion": "10.0.2",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "editorMode": "code",
-          "expr": "sum(irate(tx_cb_perf_bucket{operation=\"get_participants_end2end\"}[30s]))",
-          "instant": true,
-          "legendFormat": "Participant Callbacks / Sec",
+          "expr": "sum(rate(cbs_ing_callbackHandler_count[30s])) by (operation, success)",
+          "instant": false,
+          "legendFormat": "op:{{operation}} success: {{success}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Participant Callbacks / Sec",
-      "type": "stat"
+      "title": "Handler Ingress - Processed Per Second",
+      "type": "timeseries"
     },
     {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -203,7 +228,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 8
       },
       "hiddenSeries": false,
       "hideTimeOverride": false,
@@ -241,8 +266,12 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "editorMode": "code",
-          "expr": "sum(rate(tx_cb_perf_bucket[30s])) by (operation, success)",
+          "expr": "sum(rate(cbs_tx_cb_perf_bucket[30s])) by (operation, success)",
           "hide": false,
           "legendFormat": "op:{{operation}} - success:{{success}}",
           "range": true,
@@ -251,7 +280,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Callback Service - Proccessed per sec",
+      "title": "E2E, Request, Response Calulations Proccessed Per Second",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -286,6 +315,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -298,7 +331,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 17
       },
       "hiddenSeries": false,
       "id": 123130,
@@ -335,13 +368,17 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "editorMode": "code",
-          "expr": "avg(rate(tx_cb_perf_sum[30s]) >=0 / rate(tx_cb_perf_count[30s]) >=0) by (operation, success)",
+          "expr": "avg(rate(cbs_tx_cb_perf_sum[30s]) >=0 / rate(cbs_tx_cb_perf_count[30s]) >=0) by (operation, success)",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Op {{operation}} - Success {{success}}",
+          "legendFormat": "op:{{operation}} - Success {{success}}",
           "range": true,
           "refId": "A"
         }
@@ -360,7 +397,7 @@
         }
       ],
       "timeRegions": [],
-      "title": "Callback Service - Processing Time",
+      "title": "E2E, Request, Response Performance Timing Calculations",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -400,7 +437,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {
@@ -433,6 +470,6 @@
   "timezone": "browser",
   "title": "Supporting Services - Callback Hander Service",
   "uid": "afe9dda2-878b-40c8-90df-072e7ecaaaee",
-  "version": 4,
+  "version": 1,
   "weekStart": ""
 }

--- a/docker/grafana/provisioning/dashboards/Supporting Services - Callback Hander Service-1689261777383.json
+++ b/docker/grafana/provisioning/dashboards/Supporting Services - Callback Hander Service-1689261777383.json
@@ -1,14 +1,5 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
+  "__inputs": [],
   "__elements": {},
   "__requires": [
     {
@@ -22,12 +13,6 @@
       "id": "graph",
       "name": "Graph (old)",
       "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
     },
     {
       "type": "panel",
@@ -60,10 +45,6 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
       "description": "Party Callbacks / Sec",
       "fieldConfig": {
         "defaults": {
@@ -116,7 +97,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^Financial Transfers / sec$/",
+          "fields": "/^Party Callbacks / Sec$/",
           "values": false
         },
         "textMode": "auto"
@@ -124,14 +105,10 @@
       "pluginVersion": "10.0.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "editorMode": "code",
           "expr": "sum(irate(tx_cb_perf_bucket{operation=\"get_parties_end2end\"}[30s]))",
           "instant": true,
-          "legendFormat": "Financial Transfers / sec",
+          "legendFormat": "Party Callbacks / Sec",
           "refId": "A"
         }
       ],
@@ -139,10 +116,6 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
       "description": "Participant Callbacks / Sec",
       "fieldConfig": {
         "defaults": {
@@ -195,7 +168,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^Financial Transfers / sec$/",
+          "fields": "/^Participant Callbacks / Sec$/",
           "values": false
         },
         "textMode": "auto"
@@ -203,14 +176,10 @@
       "pluginVersion": "10.0.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "editorMode": "code",
           "expr": "sum(irate(tx_cb_perf_bucket{operation=\"get_participants_end2end\"}[30s]))",
           "instant": true,
-          "legendFormat": "Financial Transfers / sec",
+          "legendFormat": "Participant Callbacks / Sec",
           "refId": "A"
         }
       ],
@@ -222,10 +191,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -276,10 +241,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "editorMode": "code",
           "expr": "sum(rate(tx_cb_perf_bucket[30s])) by (operation, success)",
           "hide": false,
@@ -325,10 +286,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -378,10 +335,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "editorMode": "code",
           "expr": "avg(rate(tx_cb_perf_sum[30s]) >=0 / rate(tx_cb_perf_count[30s]) >=0) by (operation, success)",
           "format": "time_series",
@@ -480,6 +433,6 @@
   "timezone": "browser",
   "title": "Supporting Services - Callback Hander Service",
   "uid": "afe9dda2-878b-40c8-90df-072e7ecaaaee",
-  "version": 26,
+  "version": 4,
   "weekStart": ""
 }

--- a/docker/grafana/provisioning/dashboards/Supporting Services - Callback Hander Service-1689261777383.json
+++ b/docker/grafana/provisioning/dashboards/Supporting Services - Callback Hander Service-1689261777383.json
@@ -1,0 +1,485 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph (old)",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Party Callbacks / Sec",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 123128,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^Financial Transfers / sec$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(tx_cb_perf_bucket{operation=\"get_parties_end2end\"}[30s]))",
+          "instant": true,
+          "legendFormat": "Financial Transfers / sec",
+          "refId": "A"
+        }
+      ],
+      "title": "Party Callbacks / Sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Participant Callbacks / Sec",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
+      "id": 123129,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^Financial Transfers / sec$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(tx_cb_perf_bucket{operation=\"get_participants_end2end\"}[30s]))",
+          "instant": true,
+          "legendFormat": "Financial Transfers / sec",
+          "refId": "A"
+        }
+      ],
+      "title": "Participant Callbacks / Sec",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "hiddenSeries": false,
+      "hideTimeOverride": false,
+      "id": 123127,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sort": "min",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": true,
+      "pluginVersion": "10.0.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tx_cb_perf_bucket[30s])) by (operation, success)",
+          "hide": false,
+          "legendFormat": "op:{{operation}} - success:{{success}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Callback Service - Proccessed per sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": "",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 123130,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": true,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sort": "min",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.0.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg(rate(tx_cb_perf_sum[30s]) >=0 / rate(tx_cb_perf_count[30s]) >=0) by (operation, success)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Op {{operation}} - Success {{success}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "$$hashKey": "object:112",
+          "colorMode": "critical",
+          "fill": true,
+          "fillColor": "rgba(50, 116, 217, 0.2)",
+          "line": true,
+          "lineColor": "rgba(31, 96, 196, 0.6)",
+          "op": "gt",
+          "value": 1,
+          "yaxis": "left"
+        }
+      ],
+      "timeRegions": [],
+      "title": "Callback Service - Processing Time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:87",
+          "format": "s",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:88",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "hidden": false,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "timezone": "browser",
+  "title": "Supporting Services - Callback Hander Service",
+  "uid": "afe9dda2-878b-40c8-90df-072e7ecaaaee",
+  "version": 26,
+  "weekStart": ""
+}

--- a/packages/callback-handler-svc/config/default.json
+++ b/packages/callback-handler-svc/config/default.json
@@ -6,7 +6,7 @@
       "DISABLED": false,
       "config": {
         "timeout": 5000,
-        "prefix": "tx_",
+        "prefix": "cbs_",
         "defaultLabels": {
           "serviceName": "callback-handler-svc"
         }

--- a/packages/callback-handler-svc/src/server/index.ts
+++ b/packages/callback-handler-svc/src/server/index.ts
@@ -84,6 +84,11 @@ async function run (): Promise<void> {
     res.send(await Metrics.getMetricsForPrometheus())
   })
   app.all(['/:resource', '/:resource/*'], async (req, res) => {
+    const histTimerEnd = Metrics.getHistogram(
+      'ing_callbackHandler',
+      'Ingress - Wildcard operation handler',
+      ['success', 'operation']
+    ).startTimer()
     const currentTime = Date.now()
     const path = req.path
     const httpMethod = req.method.toLowerCase()
@@ -95,7 +100,7 @@ async function run (): Promise<void> {
     const operationResponse = `${operation}_response`
     const tracestate = getTraceStateMap(req.headers)
 
-    if (tracestate.tx_end2end_start_ts === undefined || tracestate.tx_callback_start_ts === undefined) {
+    if (tracestate?.tx_end2end_start_ts === undefined || tracestate?.tx_callback_start_ts === undefined) {
       return res.status(400).send('tx_end2end_start_ts or tx_callback_start_ts key/values not found in tracestate')
     }
 
@@ -104,7 +109,7 @@ async function run (): Promise<void> {
     const responseDelta = currentTime - tracestate.tx_callback_start_ts
 
     const performanceHistogram = Metrics.getHistogram(
-      'cb_perf',
+      'tx_cb_perf',
       'Metrics for callbacks',
       ['success', 'path', 'operation']
     )
@@ -139,6 +144,7 @@ async function run (): Promise<void> {
       }
     )
 
+    histTimerEnd({ success: true, operation })
     res.status(202)
     return res.end()
   })

--- a/packages/callback-handler-svc/test/unit/server/index.test.ts
+++ b/packages/callback-handler-svc/test/unit/server/index.test.ts
@@ -63,24 +63,7 @@ describe('start', () => {
       .set('tracestate', `tx_end2end_start_ts=${e2eStart},tx_callback_start_ts=${e2eCallbackStart}`)
       .set('traceparent', '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01')
 
-    let jsonResult: any = {}
-    expect(() => { jsonResult = JSON.parse(result.text) }).not.toThrowError()
-    expect(result.statusCode).toEqual(200)
-    expect(jsonResult).toHaveProperty('path')
-    expect(jsonResult).toHaveProperty('operation')
-    expect(jsonResult).toHaveProperty('isErrorOperation')
-    expect(jsonResult).toHaveProperty('traceparent')
-    expect(jsonResult).toHaveProperty('tracestate')
-    expect(jsonResult).toHaveProperty('serverHandlingTime')
-
-    expect(jsonResult.path).toEqual('/parties/111')
-    expect(jsonResult.operation).toEqual('put_parties')
-    expect(jsonResult.isErrorOperation).toEqual(false)
-    expect(jsonResult.tracestate.tx_end2end_start_ts).toEqual(e2eStart)
-    expect(jsonResult.tracestate.tx_callback_start_ts).toEqual(e2eCallbackStart)
-    expect(jsonResult.put_parties_request).toEqual(
-      jsonResult.tracestate.tx_callback_start_ts - jsonResult.tracestate.tx_end2end_start_ts
-    )
+    expect(result.statusCode).toEqual(202)
   })
 
   it('wildcard endpoint error callback should work', async () => {
@@ -93,24 +76,7 @@ describe('start', () => {
       .set('tracestate', `tx_end2end_start_ts=${e2eStart},tx_callback_start_ts=${e2eCallbackStart}`)
       .set('traceparent', '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01')
 
-    let jsonResult: any = {}
-    expect(() => { jsonResult = JSON.parse(result.text) }).not.toThrowError()
-    expect(result.statusCode).toEqual(200)
-    expect(jsonResult).toHaveProperty('path')
-    expect(jsonResult).toHaveProperty('operation')
-    expect(jsonResult).toHaveProperty('isErrorOperation')
-    expect(jsonResult).toHaveProperty('traceparent')
-    expect(jsonResult).toHaveProperty('tracestate')
-    expect(jsonResult).toHaveProperty('serverHandlingTime')
-
-    expect(jsonResult.path).toEqual('/parties/111/error')
-    expect(jsonResult.operation).toEqual('put_parties')
-    expect(jsonResult.isErrorOperation).toEqual(true)
-    expect(jsonResult.tracestate.tx_end2end_start_ts).toEqual(e2eStart)
-    expect(jsonResult.tracestate.tx_callback_start_ts).toEqual(e2eCallbackStart)
-    expect(jsonResult.put_parties_request).toEqual(
-      jsonResult.tracestate.tx_callback_start_ts - jsonResult.tracestate.tx_end2end_start_ts
-    )
+    expect(result.statusCode).toEqual(202)
   })
 
   it('wildcard endpoint should throw error when tracestate key values are not found', async () => {


### PR DESCRIPTION
feat(mojaloop/#3409): add initial grafana cb svc dashboard - https://github.com/mojaloop/project/issues/3409

- Add ingress metric
- Fix tests
- Add initial grafana dashboard including ingress performance and e2e/request/response timing calulations

![Supporting-Services-Callback-Hander-Service-Dashboards-Grafana](https://github.com/mojaloop/ml-core-test-harness/assets/5932442/a580d726-89e1-4ec9-99cd-dbf6d43fa5c6)