### PR TITLE
feat(3666): added quoting-handlers to docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,8 @@ ML_API_ADAPTER_VERSION=v14.0.1
 ACCOUNT_LOOKUP_SERVICE_VERSION=v14.2.3
 ## ALS snapshot release with fix: v14.2.3 + caching for validateParticipant and resolve Participants via Oracles
 # ACCOUNT_LOOKUP_SERVICE_VERSION=v14.2.4-snapshot.3
-QUOTING_SERVICE_VERSION=v15.0.2
+#QUOTING_SERVICE_VERSION=v15.0.2
+QUOTING_SERVICE_VERSION=v15.5.1-snapshot.0
 ## CL initial baseline with version included in Mojaloop v15.1.0 Helm Release
 CENTRAL_LEDGER_VERSION=v17.0.3
 ## CL snapshot release with included fix: JSON.stringify disabled in logResponse function

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,26 @@ networks:
   mojaloop-net:
     name: mojaloop-net
 
+x-quoting-service-base: &quoting-service-base
+  # https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields
+  image: "mojaloop/quoting-service:${QUOTING_SERVICE_VERSION}"
+  container_name: quoting-service
+  networks:
+    - mojaloop-net
+  depends_on: &quoting-service-base-depends-on
+    mysql:
+      condition: service_started
+    central-ledger:
+      condition: service_started
+  volumes:
+    - ./docker/config-modifier:/opt/app/config-modifier
+  user: root
+  profiles:
+    - quoting-service
+    - agreement
+    - all-services
+
+
 services:
 
   ## Switch
@@ -11,8 +31,8 @@ services:
     image: mojaloop/central-ledger:${CENTRAL_LEDGER_VERSION}
     container_name: central-ledger
     command: sh -c "/opt/app/config-modifier/run.js /opt/app/config/default.json /opt/app/config-modifier/configs/central-ledger.js /opt/app/config/default.json && /opt/app/wait4/wait4.js central-ledger && node src/api/index.js"
-    # ports:
-    #   - "3001:3001"
+    ports:
+      - "3001:3001"
     volumes:
        - ./docker/wait4:/opt/app/wait4
        - ./docker/config-modifier:/opt/app/config-modifier
@@ -117,8 +137,8 @@ services:
   mysql:
     image: mysql/mysql-server:${DEP_MYSQL_VERSION}
     container_name: mysql
-    # ports:
-    #   - "3306:3306"
+    ports:
+      - "3306:3306"
     volumes:
       # Note: this fixes the permissions issue, but docker-compose up will fail on first attempt
       - ./docker/sql-init/:/docker-entrypoint-initdb.d/
@@ -143,37 +163,32 @@ services:
       - all-services
 
   quoting-service:
-    image: "mojaloop/quoting-service:${QUOTING_SERVICE_VERSION}"
-    container_name: quoting-service
+    <<: *quoting-service-base
     command: sh -c "/opt/app/config-modifier/run.js /opt/app/config/default.json /opt/app/config-modifier/configs/quoting-service.js /opt/app/config/default.json && node src/index.js"
-    networks:
-      - mojaloop-net
-    depends_on:
-      mysql:
-        condition: service_started
-      central-ledger:
-        condition: service_started
     # ports:
     #   - "3002:3002"
-    volumes:
-      - ./docker/config-modifier:/opt/app/config-modifier
     healthcheck:
       test: wget -q http://localhost:3002/health -O /dev/null || exit 1
       timeout: 20s
       retries: 30
       interval: 15s
-    user: root
-    profiles:
-      - quoting-service
-      - agreement
-      - all-services
+
+  quoting-handlers:
+    <<: *quoting-service-base
+    command: sh -c "/opt/app/config-modifier/run.js /opt/app/config/default.json /opt/app/config-modifier/configs/quoting-service.js /opt/app/config/default.json && npm run start:handlers"
+    container_name: quoting-handlers
+    depends_on:
+      <<: *quoting-service-base-depends-on
+      kafka:
+        condition: service_started
+    # todo: add healthcheck for quoting-handlers
 
   ml-api-adapter:
     image: mojaloop/ml-api-adapter:${ML_API_ADAPTER_VERSION}
     container_name: ml-api-adapter
     command: sh -c "/opt/app/config-modifier/run.js /opt/app/config/default.json /opt/app/config-modifier/configs/ml-api-adapter.js /opt/app/config/default.json && /opt/app/wait4/wait4.js ml-api-adapter && node src/api/index.js"
-    # ports:
-    #   - "3000:3000"
+    ports:
+      - "3000:3000"
     volumes:
       - ./docker/wait4:/opt/app/wait4
       - ./docker/config-modifier:/opt/app/config-modifier

--- a/docker/config-modifier/configs/quoting-service.js
+++ b/docker/config-modifier/configs/quoting-service.js
@@ -3,5 +3,103 @@ module.exports = {
   "DATABASE": {
     "HOST": "mysql"
   },
-  "SWITCH_ENDPOINT": "http://central-ledger:3001"
+  "SWITCH_ENDPOINT": "http://central-ledger:3001",
+  "KAFKA": {
+    "CONSUMER": {
+      "QUOTE": {
+        "POST": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        },
+        "PUT": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        },
+        "GET": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        }
+      },
+      "BULK_QUOTE": {
+        "POST": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        },
+        "PUT": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        },
+        "GET": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        }
+      }
+    },
+    "PRODUCER": {
+      "QUOTE": {
+        "POST": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        },
+        "PUT": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        },
+        "GET": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        }
+      },
+      "BULK_QUOTE": {
+        "POST": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        },
+        "PUT": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        },
+        "GET": {
+          "config": {
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:29092"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/docker/kafka/scripts/provision.sh
+++ b/docker/kafka/scripts/provision.sh
@@ -26,6 +26,13 @@ topics=(
   "topic-bulk-fulfil"
   "topic-bulk-processing"
   "topic-bulk-get"
+
+  "topic-quotes-post"
+  "topic-quotes-put"
+  "topic-quotes-get"
+  "topic-bulkquotes-post"
+  "topic-bulkquotes-put"
+  "topic-bulkquotes-get"
 )
 
 # Loop through the topics and create them using kafka-topics.sh

--- a/docker/wait4/wait4.config.js
+++ b/docker/wait4/wait4.config.js
@@ -33,11 +33,11 @@ module.exports = {
           },
           retries: 60
         },
-        {
-          description: 'MongoDB object store',
-          uri: 'mongodb://objstore:27017/mlos',
-          method: 'mongo'
-        }
+        // {
+        //   description: 'MongoDB object store',
+        //   uri: 'mongodb://objstore:27017/mlos',
+        //   method: 'mongo'
+        // }
       ]
     },
     {


### PR DESCRIPTION
feat(3666): added quoting-handlers to docker-compose

results of tests after running this command (with new _v15.5.1-snapshot.0_ version of _quoting-service_):
```
docker-compose --profile all-services --profile ttk-provisioning --profile ttk-tests up
```
![image](https://github.com/mojaloop/ml-core-test-harness/assets/16463615/c5344e65-cfac-40c7-8c86-c99c2a1bc3a6)

Also run TTK p2p tests from UI:
![image](https://github.com/mojaloop/ml-core-test-harness/assets/16463615/c698be2a-74d7-4be2-b77b-8b6f660c1ca6)


