### PR TITLE
fix: Health check against 0.0.0.0 instead of localhost

### DIFF
--- a/docker-compose-perf.yml
+++ b/docker-compose-perf.yml
@@ -492,7 +492,7 @@ services:
     volumes:
       - ./docker/config-modifier:/opt/app/config-modifier
     healthcheck:
-      test: wget -q http://localhost:3002/health -O /dev/null || exit 1
+      test: wget -q http://0.0.0.0:3002/health -O /dev/null || exit 1
       timeout: 20s
       retries: 30
       interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,7 @@ services:
     volumes:
       - ./docker/config-modifier:/opt/app/config-modifier
     healthcheck:
-      test: wget -q http://localhost:3002/health -O /dev/null || exit 1
+      test: wget -q http://0.0.0.0:3002/health -O /dev/null || exit 1
       timeout: 20s
       retries: 30
       interval: 15s
@@ -213,7 +213,7 @@ services:
     networks:
       - mojaloop-net
     healthcheck:
-      test: wget -q http://localhost:8444/health -O /dev/null || exit 1
+      test: wget -q http://0.0.0.0:8444/health -O /dev/null || exit 1
       timeout: 20s
       retries: 10
       interval: 30s


### PR DESCRIPTION
For the simulator & quoting service the HAPI.server is configured specifically to listen to 0.0.0.0. Other services don't set this and the default is localhost.

Now recent changes to the docker engine made a change to how localhost is resolved, it used to be ipv4 but now is ipv6.

This means for people using a later version of docker the localhost would resolve to ::1 which the quoting service and simulator do not listen to.