### PR TITLE
fix: improve Kafka topic partitioning and consumer resilience config

### DIFF
--- a/docker/config-modifier/configs/ml-api-adapter.js
+++ b/docker/config-modifier/configs/ml-api-adapter.js
@@ -27,7 +27,11 @@ module.exports = {
         "EVENT": {
           "config": {
             "rdkafkaConf": {
-              "metadata.broker.list": "kafka:29092"
+              "metadata.broker.list": "kafka:29092",
+              "session.timeout.ms": 30000,
+              "heartbeat.interval.ms": 10000,
+              "max.poll.interval.ms": 300000,
+              "partition.assignment.strategy": "cooperative-sticky"
             }
           }
         }

--- a/docker/config-modifier/configs/ml-handler-notification-kafka.js
+++ b/docker/config-modifier/configs/ml-handler-notification-kafka.js
@@ -18,7 +18,11 @@ module.exports = {
               "sync": true
             },
             "rdkafkaConf": {
-              "metadata.broker.list": "kafka:29092"
+              "metadata.broker.list": "kafka:29092",
+              "session.timeout.ms": 30000,
+              "heartbeat.interval.ms": 10000,
+              "max.poll.interval.ms": 300000,
+              "partition.assignment.strategy": "cooperative-sticky"
             }
           }
         }

--- a/docker/config-modifier/configs/ml-handler-notification.js
+++ b/docker/config-modifier/configs/ml-handler-notification.js
@@ -12,7 +12,11 @@ module.exports = {
           "config": {
             "rdkafkaConf": {
               "metadata.broker.list": "kafka:29092",
-              "enable.auto.commit": false
+              "enable.auto.commit": false,
+              "session.timeout.ms": 30000,
+              "heartbeat.interval.ms": 10000,
+              "max.poll.interval.ms": 300000,
+              "partition.assignment.strategy": "cooperative-sticky"
             }
           }
         }

--- a/docker/kafka/scripts/provision.sh
+++ b/docker/kafka/scripts/provision.sh
@@ -43,11 +43,25 @@ topics=(
   "topic-event-trace"
 )
 
+# Topics that need multiple partitions to support consumer scaling
+multi_partition_topics=(
+  "topic-notification-event"
+  "topic-transfer-position"
+  "topic-transfer-position-batch"
+)
+
 # Loop through the topics and create them using kafka-topics.sh
 for topic in "${topics[@]}"
 do
-  echo -e "--> Creating topic $topic..."
-  kafka-topics.sh --bootstrap-server $KAFKAHOST:$KAFKAPORT --create --if-not-exists --topic "$topic" --replication-factor 1 --partitions 1
+  partitions=1
+  for mp_topic in "${multi_partition_topics[@]}"; do
+    if [ "$topic" = "$mp_topic" ]; then
+      partitions=4
+      break
+    fi
+  done
+  echo -e "--> Creating topic $topic with $partitions partition(s)..."
+  kafka-topics.sh --bootstrap-server $KAFKAHOST:$KAFKAPORT --create --if-not-exists --topic "$topic" --replication-factor 1 --partitions $partitions
 done
 
 echo -e ""


### PR DESCRIPTION
## Summary

- **Multi-partition Kafka topics**: `topic-notification-event`, `topic-transfer-position`, and `topic-transfer-position-batch` now provisioned with 4 partitions (up from 1) to support consumer scaling without partition starvation.
- **rdkafka consumer tuning**: Added `session.timeout.ms=30000`, `heartbeat.interval.ms=10000`, `max.poll.interval.ms=300000`, and `partition.assignment.strategy=cooperative-sticky` to all notification consumer configs (`ml-api-adapter.js`, `ml-handler-notification.js`, `ml-handler-notification-kafka.js`).

## Context

Investigation of Kafka consumer health failures (`isAssigned=false` causing 502 health checks) revealed that:

1. All Kafka topics were created with 1 partition — any consumer scaling beyond 1 replica results in partition starvation
2. The `rdkafkaConf` for notification consumers had zero tuning beyond bare minimum (`client.id`, `group.id`, `metadata.broker.list`)
3. Default `range` partition assignment strategy causes stop-the-world rebalancing

These changes are the test harness counterpart to mojaloop/ml-api-adapter#655 which adds the same tuning to the service defaults plus a health check grace period.

## Changes

| File | Change |
|------|--------|
| `docker/kafka/scripts/provision.sh` | Multi-partition topics (4 partitions for notification, position, position-batch) |
| `docker/config-modifier/configs/ml-api-adapter.js` | Added rdkafka consumer tuning |
| `docker/config-modifier/configs/ml-handler-notification.js` | Added rdkafka consumer tuning |
| `docker/config-modifier/configs/ml-handler-notification-kafka.js` | Added rdkafka consumer tuning |

## Test plan

- [x] Validated locally: 2 ml-api-adapter consumers with 4 partitions → both assigned, both 200 OK
- [x] Validated locally: 5 consumers with 4 partitions → grace period prevents 502 during rebalance
- [x] P2P transfer test: 31/31 assertions passed (100%)
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)