### PR TITLE
fix: replace hardcoded local path with docker image for mojaloop-testing-toolkit-ui

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -516,9 +516,7 @@ services:
       - merchant-registry
 
   mojaloop-testing-toolkit-ui:
-    build:
-      context: /Users/sprak/Documents/mojaloop/LEI/ml-testing-toolkit-ui
-      dockerfile: Dockerfile
+    image: mojaloop/ml-testing-toolkit-ui:${TEST_TTK_UI_VERSION}
     container_name: mojaloop-testing-toolkit-ui
     ports:
       - "9660:6060"


### PR DESCRIPTION
 ## Problem
The `mojaloop-testing-toolkit-ui` service in `docker-compose.yml` had a hardcoded local build context path (`/Users/sprak/Documents/mojaloop/LEI/ml-testing-toolkit-ui`) from another developer's machine, causing `docker-compose up` to fail for anyone without that exact path.

## Solution
Replaced the `build` block with the pre-built Docker Hub image `mojaloop/ml-testing-toolkit-ui:${TEST_TTK_UI_VERSION}`, which was already defined in `.env` as `v16.2.0`.

RESOLVED #144  